### PR TITLE
Fix CORS for CDN requests

### DIFF
--- a/app/controllers/external_uploads_controller.rb
+++ b/app/controllers/external_uploads_controller.rb
@@ -4,6 +4,13 @@ class ExternalUploadsController < ApplicationController
   skip_before_action :require_authentication!
   before_action :set_cors_headers
 
+  def preflight
+    response.set_header("Access-Control-Allow-Headers", "*")
+    response.set_header("Access-Control-Allow-Methods", "GET, HEAD")
+    response.set_header("Access-Control-Max-Age", "86400")
+    head :no_content
+  end
+
   def show
     upload = Upload.includes(:blob).find(params[:id])
     expires_in 1.year, public: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,5 +51,6 @@ Rails.application.routes.draw do
   end
 
   # External upload redirects (must be last to avoid conflicts)
+  match "/:id/*filename", to: "external_uploads#preflight", via: :options, constraints: { id: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/ }
   get "/:id/*filename", to: "external_uploads#show", constraints: { id: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/ }, as: :external_upload
 end

--- a/test/controllers/external_uploads_controller_test.rb
+++ b/test/controllers/external_uploads_controller_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class ExternalUploadsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @file_path = external_upload_path(id: SecureRandom.uuid, filename: "test.png")
+  end
+
+  test "preflight permits range requests" do
+    options @file_path, headers: {
+      "Origin" => "https://example.com",
+      "Access-Control-Request-Method" => "GET",
+      "Access-Control-Request-Headers" => "range, x-accept-encoding"
+    }
+
+    assert_response :no_content
+    assert_equal "*", response.headers["Access-Control-Allow-Origin"]
+    assert_equal "*", response.headers["Access-Control-Allow-Headers"]
+    assert_equal "GET, HEAD", response.headers["Access-Control-Allow-Methods"]
+    assert_equal "86400", response.headers["Access-Control-Max-Age"]
+  end
+end


### PR DESCRIPTION
Currently, CORS requests (`fetch()`, images and stuff are fine) to CDN urls fail. Three issues, important first:

1. On `user-cdn.hackclub-assets.com`, when an Origin header is present, two new response headers  are added:

```diff
  access-control-allow-origin: *
+ Access-Control-Allow-Origin: *
+ Vary: Origin, accept-encoding
```

Having two ACAO headers breaks CORS, Chrome throws `MultipleAllowOriginValues`. This isn't broken in code, it's broken in the Cloudflare dashboard for `user-cdn`. I suspect there's a Transform Rule that sets `Access-Control-Allow-Origin = *` or something, which should be removed.

2. If the client wants to send a request that isn't a "[simple request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS#simple_requests)" (in my case, [v86](https://copy.sh/v86) [uses](https://github.com/copy/v86/blob/2f1346b/src/lib.js#L647) `X-Accept-Encoding`), it first sends an OPTIONS preflight request to `user-cdn.hackclub-assets.com`. R2 handles that with a CORS policy, which should be broadened to:

```json
[
  {
    "AllowedOrigins": ["*"],
    "AllowedMethods": ["GET", "HEAD"],
    "AllowedHeaders": ["*"],
    "ExposeHeaders": [
      "Accept-Ranges",
      "Content-Range",
      "Content-Disposition",
      "Content-Encoding",
      "ETag"
    ],
    "MaxAgeSeconds": 86400
  }
]
```

3. The browser will also send a preflight request to `cdn.hackclub.com`, and it doesn't respond. This PR adds a simple handler to respond to those OPTIONS requests.

This PR only fixes the third issue in Rails, the other two need to be fixed in the Cloudflare dashboard.