### PR TITLE
Allow CDN preflight requests without CSRF tokens

### DIFF
--- a/app/controllers/external_uploads_controller.rb
+++ b/app/controllers/external_uploads_controller.rb
@@ -2,6 +2,7 @@
 
 class ExternalUploadsController < ApplicationController
   skip_before_action :require_authentication!
+  skip_forgery_protection
   before_action :set_cors_headers
 
   def preflight

--- a/test/controllers/external_uploads_controller_test.rb
+++ b/test/controllers/external_uploads_controller_test.rb
@@ -6,6 +6,9 @@ class ExternalUploadsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "preflight permits range requests" do
+    original_forgery_protection = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+
     options @file_path, headers: {
       "Origin" => "https://example.com",
       "Access-Control-Request-Method" => "GET",
@@ -17,5 +20,7 @@ class ExternalUploadsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "*", response.headers["Access-Control-Allow-Headers"]
     assert_equal "GET, HEAD", response.headers["Access-Control-Allow-Methods"]
     assert_equal "86400", response.headers["Access-Control-Max-Age"]
+  ensure
+    ActionController::Base.allow_forgery_protection = original_forgery_protection
   end
 end


### PR DESCRIPTION
OPTIONS requests won't have a CSRF token, and the test missed that bc they disable CSRF

Fixes #100